### PR TITLE
Preserve symlinks

### DIFF
--- a/lipo-dir-merge.py
+++ b/lipo-dir-merge.py
@@ -57,5 +57,5 @@ def copy_file_or_merge_libs(src, dst, *, follow_symlinks=True):
         shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
 
 # Use copytree to do most of the work, with our own `copy_function` doing a little bit
-# of magic in case of static libraries.
-shutil.copytree(primary_path, destination_path, copy_function=copy_file_or_merge_libs)
+# of magic in case of libraries.
+shutil.copytree(primary_path, destination_path, copy_function=copy_file_or_merge_libs, symlinks=True)


### PR DESCRIPTION
In my case symlinks should be preserved (`libQt6Gui.dylib` and `libQt6Gui.6.dylib` should link to `libQt6Gui.6.8.1.dylib`). If the files instead of the symlinks are copied, we get crashes.