### PR TITLE
Fixes #10: Fix command-line script functionality with pip install

### DIFF
--- a/lipomerge.py
+++ b/lipomerge.py
@@ -1,62 +1,37 @@
 # Copyright (C) Falko Axmann. All rights reserved.
 # Licensed under the GPL v3 license.
-
 """
 This script merges two directories containing static libraries for
 two different architectures into one directory with universal binaries.
 Files that don't end in ".a" will just be copied over from the first directory.
-
 Run it like this:
  `python3 lipomerge.py <arm64-dir-tree> <x64-dir-tree> <universal-output-dir>`
 """
-
 import os
 import shutil
 import subprocess
 import sys
 
-#
-# Make sure we got enough arguments on the command line
-#
-if len(sys.argv) < 4:
-    print("Not enough args")
-    print(
-        f"{sys.argv[0]} <primary directory> <other architecture source> <destination>"
-    )
-    sys.exit(-1)
-
-# This is where we take most of the files from
-primary_path = sys.argv[1]
-# This is the directory tree from which we take libraries of the alternative arch
-secondary_path = sys.argv[2]
-# This is where we copy stuff to
-destination_path = sys.argv[3]
-
 
 def is_macho(filepath: str) -> bool:
     """
     Checks if a file is a Mach-O binary by reading the first 4 bytes.
-
     Args:
         filepath: Path to the file to check
-
     Returns:
         True if it is a Mach-O file
     """
     # Mach-O magic numbers
     MAGIC_64 = 0xCFFAEDFE  # 64-bit mach-o
     MAGIC_32 = 0xCEFAEDFE  # 32-bit mach-o
-
     try:
         # Open file in binary mode and read first 4 bytes
         with open(filepath, "rb") as f:
             magic = int.from_bytes(f.read(4), byteorder="big")
-
         if magic in (MAGIC_64, MAGIC_32):
             return True
         else:
             return False
-
     except (IOError, OSError):
         return False
 
@@ -65,7 +40,6 @@ def merge_libs(src1, src2, dst):
     """
     Merge the libraries at `src1` and `src2` and create a
     universal binary at `dst`.
-
     Args:
         src1: Path to the first architecture library
         src2: Path to the second architecture library
@@ -74,45 +48,73 @@ def merge_libs(src1, src2, dst):
     subprocess.run(["lipo", "-create", src1, src2, "-output", dst])
 
 
-def find_and_merge_libs(src, dst):
+def find_and_merge_libs(primary_path, secondary_path, src, dst):
     """
     Find the library at `src` in the `secondary_path` and then
     merge the two versions, creating a universal binary at `dst`.
-
     Args:
+        primary_path: Base path of the primary directory
+        secondary_path: Base path of the secondary directory
         src: Path to the library in the primary directory
         dst: Destination path for the universal binary
     """
     rel_path = os.path.relpath(src, primary_path)
     lib_in_secondary = os.path.join(secondary_path, rel_path)
-
     if os.path.exists(lib_in_secondary) == False:
         print(f"Lib not found in secondary source: {lib_in_secondary}")
         return
-
     merge_libs(src, lib_in_secondary, dst)
 
 
-def copy_file_or_merge_libs(src, dst, *, follow_symlinks=True):
+def copy_file_or_merge_libs(
+    primary_path, secondary_path, src, dst, *, follow_symlinks=True
+):
     """
     Either copy the file at `src` to `dst`, or, if it is a static
     library, merge it with its version from `secondary_path` and
     write the universal binary to `dst`.
-
     Args:
+        primary_path: Base path of the primary directory
+        secondary_path: Base path of the secondary directory
         src: Source file path
         dst: Destination file path
         follow_symlinks: Whether to follow symlinks when copying
     """
     _, file_ext = os.path.splitext(src)
-    if not os.path.islink(src) and (file_ext == ".a") or is_macho(src):
-        find_and_merge_libs(src, dst)
+    if not os.path.islink(src) and (file_ext == ".a" or is_macho(src)):
+        find_and_merge_libs(primary_path, secondary_path, src, dst)
     else:
         shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
 
 
-# Use copytree to do most of the work, with our own `copy_function` doing a little bit
-# of magic in case of libraries.
-shutil.copytree(
-    primary_path, destination_path, copy_function=copy_file_or_merge_libs, symlinks=True
-)
+def main():
+    """Main entry point for the lipomerge tool."""
+    # Make sure we got enough arguments on the command line
+    if len(sys.argv) < 4:
+        print("Not enough args")
+        print(
+            f"{sys.argv[0]} <primary directory> <other architecture source> <destination>"
+        )
+        sys.exit(-1)
+
+    # This is where we take most of the files from
+    primary_path = sys.argv[1]
+    # This is the directory tree from which we take libraries of the alternative arch
+    secondary_path = sys.argv[2]
+    # This is where we copy stuff to
+    destination_path = sys.argv[3]
+
+    # Use copytree to do most of the work, with our own `copy_function` doing a little bit
+    # of magic in case of libraries.
+    def copy_func(src, dst, *, follow_symlinks=True):
+        return copy_file_or_merge_libs(
+            primary_path, secondary_path, src, dst, follow_symlinks=follow_symlinks
+        )
+
+    shutil.copytree(
+        primary_path, destination_path, copy_function=copy_func, symlinks=True
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,5 @@ setup(
             "lipomerge=lipomerge:main",
         ],
     },
+    test_suite="test",
 )

--- a/test.py
+++ b/test.py
@@ -1,0 +1,151 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+import lipomerge
+
+
+class TestLipomerge(unittest.TestCase):
+    def setUp(self):
+        self.primary_dir = tempfile.mkdtemp()
+        self.secondary_dir = tempfile.mkdtemp()
+        self.output_dir = tempfile.mktemp()
+
+        self.setup_test_files()
+
+    def tearDown(self):
+        shutil.rmtree(self.primary_dir, ignore_errors=True)
+        shutil.rmtree(self.secondary_dir, ignore_errors=True)
+        if os.path.exists(self.output_dir):
+            shutil.rmtree(self.output_dir, ignore_errors=True)
+
+    def setup_test_files(self):
+        os.makedirs(os.path.join(self.primary_dir, "lib"))
+        with open(os.path.join(self.primary_dir, "lib", "libtest.a"), "wb") as f:
+            f.write(b"primary arch library")
+
+        with open(os.path.join(self.primary_dir, "regular.txt"), "w") as f:
+            f.write("regular text file")
+
+        os.makedirs(os.path.join(self.secondary_dir, "lib"))
+        with open(os.path.join(self.secondary_dir, "lib", "libtest.a"), "wb") as f:
+            f.write(b"secondary arch library")
+
+    @patch("lipomerge.subprocess.run")
+    def test_merge_libraries(self, mock_run):
+        """Test that libraries are properly merged using lipo"""
+
+        def is_macho_side_effect(filepath):
+            return filepath.endswith(".a") or "binary" in filepath
+
+        with patch("lipomerge.is_macho", side_effect=is_macho_side_effect):
+            with patch(
+                "sys.argv",
+                ["lipomerge.py", self.primary_dir, self.secondary_dir, self.output_dir],
+            ):
+                lipomerge.main()
+
+        mock_run.assert_called_with(
+            [
+                "lipo",
+                "-create",
+                os.path.join(self.primary_dir, "lib", "libtest.a"),
+                os.path.join(self.secondary_dir, "lib", "libtest.a"),
+                "-output",
+                os.path.join(self.output_dir, "lib", "libtest.a"),
+            ]
+        )
+
+        self.assertTrue(os.path.exists(os.path.join(self.output_dir, "regular.txt")))
+        with open(os.path.join(self.output_dir, "regular.txt"), "r") as f:
+            content = f.read()
+        self.assertEqual(content, "regular text file")
+
+    @patch("lipomerge.subprocess.run")
+    def test_handle_missing_secondary_file(self, mock_run):
+        """Test behavior when a file exists in primary but not in secondary dir"""
+        os.remove(os.path.join(self.secondary_dir, "lib", "libtest.a"))
+
+        def is_macho_side_effect(filepath):
+            return filepath.endswith(".a") or "binary" in filepath
+
+        with patch("lipomerge.is_macho", side_effect=is_macho_side_effect):
+            with patch("builtins.print") as mock_print:
+                with patch(
+                    "sys.argv",
+                    [
+                        "lipomerge.py",
+                        self.primary_dir,
+                        self.secondary_dir,
+                        self.output_dir,
+                    ],
+                ):
+                    lipomerge.main()
+
+            expected_message = f"Lib not found in secondary source: {os.path.join(self.secondary_dir, 'lib', 'libtest.a')}"
+            mock_print.assert_any_call(expected_message)
+
+        self.assertTrue(os.path.exists(os.path.join(self.output_dir, "regular.txt")))
+        self.assertFalse(
+            mock_run.called, "lipo should not be called when secondary file is missing"
+        )
+
+    def test_macho_binary_detection(self):
+        """Test that Mach-O binaries are correctly detected and merged"""
+        with open(os.path.join(self.primary_dir, "binary"), "wb") as f:
+            f.write(b"fake binary")
+        with open(os.path.join(self.secondary_dir, "binary"), "wb") as f:
+            f.write(b"fake secondary binary")
+
+        def is_macho_side_effect(filepath):
+            return filepath.endswith(".a") or "binary" in filepath
+
+        expected_calls = [
+            call(
+                [
+                    "lipo",
+                    "-create",
+                    os.path.join(self.primary_dir, "lib", "libtest.a"),
+                    os.path.join(self.secondary_dir, "lib", "libtest.a"),
+                    "-output",
+                    os.path.join(self.output_dir, "lib", "libtest.a"),
+                ]
+            ),
+            call(
+                [
+                    "lipo",
+                    "-create",
+                    os.path.join(self.primary_dir, "binary"),
+                    os.path.join(self.secondary_dir, "binary"),
+                    "-output",
+                    os.path.join(self.output_dir, "binary"),
+                ]
+            ),
+        ]
+
+        with patch("lipomerge.is_macho", side_effect=is_macho_side_effect):
+            with patch("lipomerge.subprocess.run") as mock_run:
+                with patch(
+                    "sys.argv",
+                    [
+                        "lipomerge.py",
+                        self.primary_dir,
+                        self.secondary_dir,
+                        self.output_dir,
+                    ],
+                ):
+                    lipomerge.main()
+
+                self.assertEqual(
+                    len(mock_run.call_args_list),
+                    2,
+                    "lipo should be called exactly twice",
+                )
+                for expected_call in expected_calls:
+                    self.assertIn(expected_call, mock_run.call_args_list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import call, patch
 
 import lipomerge
 


### PR DESCRIPTION
## Fix

Refactored the code to add a proper `main()` function entry point:
- Moved command-line argument handling code into a `main()` function
- Added `if __name__ == "__main__"` guard for direct script execution
- Restructured functions to receive path parameters rather than using globals
- Ensured compatibility with the existing entry_point in setup.py
- Formatted with black

This change should maintain backward compatibility while enabling the tool to work as a proper pip-installable command-line application.